### PR TITLE
Local Risc0 Verifier

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "lib/forge-std"]
 	path = lib/forge-std
 	url = https://github.com/foundry-rs/forge-std
+[submodule "lib/risc0-ethereum"]
+	path = lib/risc0-ethereum
+	url = https://github.com/risc0/risc0-ethereum

--- a/Makefile
+++ b/Makefile
@@ -6,3 +6,24 @@ all: build_contracts
 
 build_contracts:
 	cd $(BUILD_DIR) && forge build
+
+deploy-risc0-verifier: clean
+	git clone https://github.com/risc0/risc0-ethereum.git
+	echo '--- a/contracts/script/DeployVerifier.s.sol' > /tmp/my_patch.diff; \
+	echo '+++ b/contracts/script/DeployVerifier.s.sol' >> /tmp/my_patch.diff; \
+	echo '@@ -33,7 +33,7 @@ contract DeployVerifier is Script {' >> /tmp/my_patch.diff; \
+	echo '' >> /tmp/my_patch.diff; \
+	echo '         vm.startBroadcast(deployerKey);' >> /tmp/my_patch.diff; \
+	echo '' >> /tmp/my_patch.diff; \
+	echo '-        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(ControlID.CONTROL_ROOT, ControlID.BN254_CONTROL_ID);' >> /tmp/my_patch.diff; \
+	echo '+        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(hex"8cdad9242664be3112aba377c5425a4df735eb1c6966472b561d2855932c0469", ControlID.BN254_CONTROL_ID);' >> /tmp/my_patch.diff; \
+	echo '         console2.log("Deployed RiscZeroGroth16Verifier to", address(verifier));' >> /tmp/my_patch.diff; \
+	echo '' >> /tmp/my_patch.diff; \
+	echo '         vm.stopBroadcast();' >> /tmp/my_patch.diff;
+	cd risc0-ethereum && git apply /tmp/my_patch.diff && git submodule update --init --recursive && ETH_WALLET_PRIVATE_KEY=$(ETH_WALLET_PRIVATE_KEY) forge script contracts/script/DeployVerifier.s.sol:DeployVerifier --rpc-url $(RPC_URL) --broadcast -vvvv
+	rm -f /tmp/my_patch.diffg
+	rm -rf risc0-ethereum
+
+clean:
+	rm -rf risc0-ethereum
+	rm -f /tmp/my_patch.diff

--- a/Makefile
+++ b/Makefile
@@ -9,19 +9,24 @@ build_contracts:
 
 deploy-risc0-verifier: clean
 	git clone https://github.com/risc0/risc0-ethereum.git
-	echo '--- a/contracts/script/DeployVerifier.s.sol' > /tmp/my_patch.diff; \
-	echo '+++ b/contracts/script/DeployVerifier.s.sol' >> /tmp/my_patch.diff; \
-	echo '@@ -33,7 +33,7 @@ contract DeployVerifier is Script {' >> /tmp/my_patch.diff; \
-	echo '' >> /tmp/my_patch.diff; \
-	echo '         vm.startBroadcast(deployerKey);' >> /tmp/my_patch.diff; \
-	echo '' >> /tmp/my_patch.diff; \
-	echo '-        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(ControlID.CONTROL_ROOT, ControlID.BN254_CONTROL_ID);' >> /tmp/my_patch.diff; \
-	echo '+        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(hex"8cdad9242664be3112aba377c5425a4df735eb1c6966472b561d2855932c0469", ControlID.BN254_CONTROL_ID);' >> /tmp/my_patch.diff; \
-	echo '         console2.log("Deployed RiscZeroGroth16Verifier to", address(verifier));' >> /tmp/my_patch.diff; \
-	echo '' >> /tmp/my_patch.diff; \
-	echo '         vm.stopBroadcast();' >> /tmp/my_patch.diff;
-	cd risc0-ethereum && git apply /tmp/my_patch.diff && git submodule update --init --recursive && ETH_WALLET_PRIVATE_KEY=$(ETH_WALLET_PRIVATE_KEY) forge script contracts/script/DeployVerifier.s.sol:DeployVerifier --rpc-url $(RPC_URL) --broadcast -vvvv
-	rm -f /tmp/my_patch.diffg
+	printf '%s\n' \
+		'--- a/contracts/script/DeployVerifier.s.sol' \
+		'+++ b/contracts/script/DeployVerifier.s.sol' \
+		'@@ -33,7 +33,7 @@ contract DeployVerifier is Script {' \
+		'' \
+		'         vm.startBroadcast(deployerKey);' \
+		'' \
+		'-        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(ControlID.CONTROL_ROOT, ControlID.BN254_CONTROL_ID);' \
+		'+        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(hex"8cdad9242664be3112aba377c5425a4df735eb1c6966472b561d2855932c0469", ControlID.BN254_CONTROL_ID);' \
+		'         console2.log("Deployed RiscZeroGroth16Verifier to", address(verifier));' \
+		'' \
+		'         vm.stopBroadcast();' \
+		> /tmp/my_patch.diff
+	cd risc0-ethereum && \
+		git apply /tmp/my_patch.diff && \
+		git submodule update --init --recursive && \
+		ETH_WALLET_PRIVATE_KEY=$(ETH_WALLET_PRIVATE_KEY) forge script contracts/script/DeployVerifier.s.sol:DeployVerifier --rpc-url $(RPC_URL) --broadcast -vvvv
+	rm -f /tmp/my_patch.diff
 	rm -rf risc0-ethereum
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -6,29 +6,3 @@ all: build_contracts
 
 build_contracts:
 	cd $(BUILD_DIR) && forge build
-
-deploy-risc0-verifier: clean
-	git clone https://github.com/risc0/risc0-ethereum.git
-	printf '%s\n' \
-		'--- a/contracts/script/DeployVerifier.s.sol' \
-		'+++ b/contracts/script/DeployVerifier.s.sol' \
-		'@@ -33,7 +33,7 @@ contract DeployVerifier is Script {' \
-		'' \
-		'         vm.startBroadcast(deployerKey);' \
-		'' \
-		'-        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(ControlID.CONTROL_ROOT, ControlID.BN254_CONTROL_ID);' \
-		'+        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(hex"8cdad9242664be3112aba377c5425a4df735eb1c6966472b561d2855932c0469", ControlID.BN254_CONTROL_ID);' \
-		'         console2.log("Deployed RiscZeroGroth16Verifier to", address(verifier));' \
-		'' \
-		'         vm.stopBroadcast();' \
-		> /tmp/my_patch.diff
-	cd risc0-ethereum && \
-		git apply /tmp/my_patch.diff && \
-		git submodule update --init --recursive && \
-		ETH_WALLET_PRIVATE_KEY=$(ETH_WALLET_PRIVATE_KEY) forge script contracts/script/DeployVerifier.s.sol:DeployVerifier --rpc-url $(RPC_URL) --broadcast -vvvv
-	rm -f /tmp/my_patch.diff
-	rm -rf risc0-ethereum
-
-clean:
-	rm -rf risc0-ethereum
-	rm -f /tmp/my_patch.diff

--- a/README.md
+++ b/README.md
@@ -150,9 +150,9 @@ Update the BLOB_VERIFIER_WRAPPER_CONTRACT address on ```host/src/verify_blob.rs`
 
 The address on CALLER is a known address from zksync, it should be changed to the needed one in the real use case.
 
-Deploy the `Risc0Groth16Verifier`:
+Deploy the `RiscZeroGroth16Verifier`:
 ```bash
-make deploy-risc0-verifier ETH_WALLET_PRIVATE_KEY=<your_pk> RPC_URL=<your_rpc>
+ETH_WALLET_PRIVATE_KEY=<your_sk> forge script contracts/script/DeployRiscZeroGroth16Verifier.s.sol:DeployRiscZeroGroth16Verifier --rpc-url <your_rpc> --broadcast -vvvv
 ```
 
 Save the address under `Contract Address: <address>`
@@ -160,7 +160,7 @@ Save the address under `Contract Address: <address>`
 Deploy the `Risc0ProofVerifierWrapper`:
 
 ```bash
-PRIVATE_KEY=<your_pk> RISC0_VERIFIER_ADDRESS=<your_address> forge script contracts/script/Risc0ProofVerifierWrapperDeployer.s.sol:Risc0ProofVerifierWrapperDeployer --rpc-url <your_rpc> --broadcast -vvvv
+PRIVATE_KEY=<your_sk> RISC0_VERIFIER_ADDRESS=<your_address> forge script contracts/script/Risc0ProofVerifierWrapperDeployer.s.sol:Risc0ProofVerifierWrapperDeployer --rpc-url <your_rpc> --broadcast -vvvv
 ```
 
 Keep the contract address at hand for the next command.

--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Deploy the `Risc0ProofVerifierWrapper`:
 PRIVATE_KEY=<your_pk> RISC0_VERIFIER_ADDRESS=<your_address> forge script contracts/script/Risc0ProofVerifierWrapperDeployer.s.sol:Risc0ProofVerifierWrapperDeployer --rpc-url <your_rpc> --broadcast -vvvv
 ```
 
-Save the address.
+Keep the contract address at hand for the next command.
 
 To run the example execute the following command:
 

--- a/README.md
+++ b/README.md
@@ -150,18 +150,25 @@ Update the BLOB_VERIFIER_WRAPPER_CONTRACT address on ```host/src/verify_blob.rs`
 
 The address on CALLER is a known address from zksync, it should be changed to the needed one in the real use case.
 
-If necessary, deploy the `Risc0ProofVerifierWrapper`:
+Deploy the `Risc0Groth16Verifier`:
+```bash
+make deploy-risc0-verifier ETH_WALLET_PRIVATE_KEY=<your_pk> RPC_URL=<your_rpc>
+```
+
+Save the address under `Contract Address: <address>`
+
+Deploy the `Risc0ProofVerifierWrapper`:
 
 ```bash
 PRIVATE_KEY=<your_pk> RISC0_VERIFIER_ADDRESS=<your_address> forge script contracts/script/Risc0ProofVerifierWrapperDeployer.s.sol:Risc0ProofVerifierWrapperDeployer --rpc-url <your_rpc> --broadcast -vvvv
 ```
 
-There is already one deployed in holesky: `0x25b0F3F5434924821Ad73Eed8C7D81Db87DB0a15`
+Save the address.
 
 To run the example execute the following command:
 
 ```bash
-RPC_URL=<your_rpc> PRIVATE_KEY=<your_private_key> PROOF_VERIFIER_RPC=<your_rpc> RUST_LOG=info cargo run --release
+RPC_URL=<your_rpc> PRIVATE_KEY=<your_private_key> RISC0_VERIFIER_WRAPPER=<your_risc0_verifier_address> RUST_LOG=info cargo run --release
 ```
 
 

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -18,6 +18,10 @@ There are also scripts that are used to make use of the contracts easier.
 
 Deploys the `BlobVerifierWrapper`
 
+## DeployRiscZeroGroth16Verifier
+
+Deploys the risc0 groth16 verifier using the risc0-ethereum contracts
+
 ## Risc0ProofVerifierWrapperDeployer
 
 Deploys the `Risc0ProofVerifierWrapper`

--- a/contracts/script/DeployRiscZeroGroth16Verifier.s.sol
+++ b/contracts/script/DeployRiscZeroGroth16Verifier.s.sol
@@ -1,0 +1,42 @@
+// Copyright 2025 RISC Zero, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+pragma solidity ^0.8.20;
+
+import {Script} from "forge-std/Script.sol";
+import {console2} from "forge-std/console2.sol";
+import {IRiscZeroVerifier} from "risc0-ethereum/IRiscZeroVerifier.sol";
+import {ControlID, RiscZeroGroth16Verifier} from "risc0-ethereum/groth16/RiscZeroGroth16Verifier.sol";
+
+/// @notice Deployment script for the RISC Zero verifier.
+/// @dev Use the following environment variable to control the deployment:
+///     * ETH_WALLET_PRIVATE_KEY private key of the wallet to be used for deployment.
+///
+/// See the Foundry documentation for more information about Solidity scripts.
+/// https://book.getfoundry.sh/tutorials/solidity-scripting
+contract DeployRiscZeroGroth16Verifier is Script {
+    function run() external {
+        uint256 deployerKey = uint256(vm.envBytes32("ETH_WALLET_PRIVATE_KEY"));
+
+        vm.startBroadcast(deployerKey);
+
+        // The first parameter is hardcoded since that is the parameter used in the RISC Zero Groth16 verifier that is deployed in holesky.
+        IRiscZeroVerifier verifier = new RiscZeroGroth16Verifier(hex"8cdad9242664be3112aba377c5425a4df735eb1c6966472b561d2855932c0469", ControlID.BN254_CONTROL_ID);
+        console2.log("Deployed RiscZeroGroth16Verifier to", address(verifier));
+
+        vm.stopBroadcast();
+    }
+}

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -28,9 +28,9 @@ struct Args {
     /// Private key to verify the proof
     #[arg(short, long, env = "PRIVATE_KEY")]
     private_key: Secret<String>,
-    /// Rpc were the proof should be verified
-    #[arg(short, long, env = "PROOF_VERIFIER_RPC")]
-    proof_verifier_rpc: Secret<String>,
+    /// Address of the Risc0 Verifier Wrapper
+    #[arg(short, long, env = "RISC0_VERIFIER_WRAPPER")]
+    risc0_verifier_address: String,
 }
 
 #[tokio::main]
@@ -82,7 +82,8 @@ async fn main() -> Result<()> {
                 session_info,
                 args.private_key.clone(),
                 blob_verification_proof.blobIndex,
-                args.proof_verifier_rpc.clone(),
+                args.rpc_url.clone(),
+                args.risc0_verifier_address.clone()
             )
             .await?;
         }

--- a/host/src/prove_risc0.rs
+++ b/host/src/prove_risc0.rs
@@ -22,7 +22,7 @@ pub async fn prove_risc0_proof(
     session_info: ProveInfo,
     private_key: Secret<String>,
     blob_index: u32,
-    rpc: Url,
+    eth_rpc: Url,
     risc0_verifier_address: String,
 ) -> anyhow::Result<()> {
     let image_id = compute_image_id(BLOB_VERIFICATION_GUEST_ELF)?;
@@ -54,7 +54,7 @@ pub async fn prove_risc0_proof(
     let wallet = EthereumWallet::from(signer);
     let provider = ProviderBuilder::new()
         .wallet(wallet)
-        .on_http(rpc);
+        .on_http(eth_rpc);
 
     let risc0_verifier_contract_address: Address = risc0_verifier_address
         .parse()

--- a/host/src/prove_risc0.rs
+++ b/host/src/prove_risc0.rs
@@ -9,6 +9,7 @@ use blob_verification_methods::BLOB_VERIFICATION_GUEST_ELF;
 use risc0_zkvm::ProveInfo;
 use risc0_zkvm::{compute_image_id, sha::Digestible};
 use secrecy::{ExposeSecret, Secret};
+use url::Url;
 
 sol!(
     #[sol(rpc)]
@@ -21,7 +22,8 @@ pub async fn prove_risc0_proof(
     session_info: ProveInfo,
     private_key: Secret<String>,
     blob_index: u32,
-    proof_verifier_rpc: Secret<String>,
+    proof_verifier_rpc: Url,
+    risc0_verifier_address: String,
 ) -> anyhow::Result<()> {
     let image_id = compute_image_id(BLOB_VERIFICATION_GUEST_ELF)?;
     let image_id: risc0_zkvm::sha::Digest = image_id.into();
@@ -52,13 +54,13 @@ pub async fn prove_risc0_proof(
     let wallet = EthereumWallet::from(signer);
     let provider = ProviderBuilder::new()
         .wallet(wallet)
-        .on_http(proof_verifier_rpc.expose_secret().parse()?);
+        .on_http(proof_verifier_rpc);
 
-    let contract_address: Address = "0x25b0F3F5434924821Ad73Eed8C7D81Db87DB0a15"
+    let risc0_verifier_contract_address: Address = risc0_verifier_address
         .parse()
         .expect("Invalid contract address");
 
-    let contract = IRiscZeroVerifier::new(contract_address, &provider);
+    let contract = IRiscZeroVerifier::new(risc0_verifier_contract_address, &provider);
 
     let pending_tx = contract
         .verify(

--- a/host/src/prove_risc0.rs
+++ b/host/src/prove_risc0.rs
@@ -22,7 +22,7 @@ pub async fn prove_risc0_proof(
     session_info: ProveInfo,
     private_key: Secret<String>,
     blob_index: u32,
-    proof_verifier_rpc: Url,
+    rpc: Url,
     risc0_verifier_address: String,
 ) -> anyhow::Result<()> {
     let image_id = compute_image_id(BLOB_VERIFICATION_GUEST_ELF)?;
@@ -54,7 +54,7 @@ pub async fn prove_risc0_proof(
     let wallet = EthereumWallet::from(signer);
     let provider = ProviderBuilder::new()
         .wallet(wallet)
-        .on_http(proof_verifier_rpc);
+        .on_http(rpc);
 
     let risc0_verifier_contract_address: Address = risc0_verifier_address
         .parse()

--- a/remappings.txt
+++ b/remappings.txt
@@ -1,1 +1,3 @@
 forge-std/=lib/forge-std/src/
+risc0-ethereum/=lib/risc0-ethereum/contracts/src/
+openzeppelin/=lib/risc0-ethereum/lib/openzeppelin-contracts/


### PR DESCRIPTION
This PR adds a step to deploy a local `Risc0Groth16Verifier`, we used to use one already deployed on holesky.
This contract is the one responsible for the verification of the groth16 proofs that risc0 generates, it is provided in [risc0-ethereum](https://github.com/risc0/risc0-ethereum/blob/main/contracts/src/groth16/RiscZeroGroth16Verifier.sol).
In order to integrate with zksync we need to have everything in the same L1, so we need this contract deployed locally