### PR TITLE
Return full journal

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2206,7 +2206,6 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives 1.2.0",
  "alloy-sol-types",
- "anyhow",
  "ark-bn254",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2211,6 +2211,7 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "clap",
+ "ethabi",
  "rust-eigenda-v2-common",
  "rust-kzg-bn254-primitives",
  "serde",

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -14,3 +14,4 @@ anyhow = { workspace = true }
 rust-kzg-bn254-primitives = { workspace = true }
 rust-eigenda-v2-common = { workspace = true }
 clap = { workspace = true }
+ethabi = { workspace = true }

--- a/common/Cargo.toml
+++ b/common/Cargo.toml
@@ -10,7 +10,6 @@ ark-ff = { workspace = true }
 ark-serialize = { workspace = true }
 alloy-sol-types = { workspace = true }
 alloy-primitives = { workspace = true }
-anyhow = { workspace = true }
 rust-kzg-bn254-primitives = { workspace = true }
 rust-eigenda-v2-common = { workspace = true }
 clap = { workspace = true }

--- a/common/src/output.rs
+++ b/common/src/output.rs
@@ -3,7 +3,6 @@ use ethabi::Token;
 pub struct Output {
     pub hash: Vec<u8>,
     pub env_commitment: Vec<u8>,
-    pub inclusion_data: Vec<u8>,
     pub proof: Vec<u8>,
 }
 
@@ -14,7 +13,6 @@ impl Output {
             vec![
                 Token::FixedBytes(self.hash),
                 Token::Bytes(self.env_commitment),
-                Token::Bytes(self.inclusion_data),
                 Token::Bytes(self.proof)
             ]
         )])

--- a/common/src/output.rs
+++ b/common/src/output.rs
@@ -1,9 +1,20 @@
-use serde::{Deserialize, Serialize};
+use ethabi::Token;
 
-#[derive(Serialize, Deserialize)]
 pub struct Output {
     pub hash: Vec<u8>,
     pub env_commitment: Vec<u8>,
     pub inclusion_data: Vec<u8>,
     pub proof: Vec<u8>,
+}
+
+
+impl Output {
+    pub fn abi_encode(self) -> Vec<u8> {
+        ethabi::encode(&[
+            Token::FixedBytes(self.hash),
+            Token::Bytes(self.env_commitment),
+            Token::Bytes(self.inclusion_data),
+            Token::Bytes(self.proof)
+        ])
+    }
 }

--- a/common/src/output.rs
+++ b/common/src/output.rs
@@ -10,11 +10,13 @@ pub struct Output {
 
 impl Output {
     pub fn abi_encode(self) -> Vec<u8> {
-        ethabi::encode(&[
-            Token::FixedBytes(self.hash),
-            Token::Bytes(self.env_commitment),
-            Token::Bytes(self.inclusion_data),
-            Token::Bytes(self.proof)
-        ])
+        ethabi::encode(&[Token::Tuple(
+            vec![
+                Token::FixedBytes(self.hash),
+                Token::Bytes(self.env_commitment),
+                Token::Bytes(self.inclusion_data),
+                Token::Bytes(self.proof)
+            ]
+        )])
     }
 }

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -199,15 +199,10 @@ async fn generate_proof(
         Err(_) => vec![0u8; 4],
     };
 
-    let journal_digest = Digestible::digest(&result.receipt.journal)
-        .as_bytes()
-        .to_vec();
-
     let proof = ethabi::encode(&[Token::Tuple(vec![
         Token::Bytes(block_proof),
         Token::FixedBytes(image_id),
-        Token::FixedBytes(journal_digest),
-        Token::FixedBytes(output.hash),
+        Token::Bytes(result.receipt.journal),
     ])]);
 
     Ok(proof)

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -182,7 +182,7 @@ async fn generate_proof(
 
     let block_proof = match result.receipt.inner.groth16() {
         Ok(inner) => {
-            // The SELECTOR is used to perfxorm an extra check inside the groth16 verifier contract.
+            // The SELECTOR is used to perform an extra check inside the groth16 verifier contract.
             let mut selector = hex::encode(
                 inner
                     .verifier_parameters

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -17,7 +17,7 @@ use std::{sync::Arc, time::Duration};
 use alloy_primitives::Address;
 use anyhow::Result;
 use clap::Parser;
-use common::{output::Output, polynomial_form::PolynomialForm};
+use common::polynomial_form::PolynomialForm;
 use ethabi::Token;
 use host::db::{
     mark_blob_proof_request_failed, proof_request_exists, retrieve_blob_id_proof,
@@ -26,7 +26,7 @@ use host::db::{
 use jsonrpc_core::{ErrorCode, IoHandler, Params};
 use jsonrpc_http_server::ServerBuilder;
 use methods::GUEST_ELF;
-use risc0_zkvm::{compute_image_id, sha::Digestible};
+use risc0_zkvm::compute_image_id;
 use rust_eigenda_v2_client::{
     core::BlobKey,
     payload_disperser::{PayloadDisperser, PayloadDisperserConfig},

--- a/host/src/main.rs
+++ b/host/src/main.rs
@@ -176,15 +176,13 @@ async fn generate_proof(
     )
     .await?;
 
-    let output: Output = result.receipt.journal.decode()?;
-
     let image_id = compute_image_id(GUEST_ELF)?;
     let image_id: risc0_zkvm::sha::Digest = image_id;
     let image_id = image_id.as_bytes().to_vec();
 
     let block_proof = match result.receipt.inner.groth16() {
         Ok(inner) => {
-            // The SELECTOR is used to perform an extra check inside the groth16 verifier contract.
+            // The SELECTOR is used to perfxorm an extra check inside the groth16 verifier contract.
             let mut selector = hex::encode(
                 inner
                     .verifier_parameters
@@ -202,7 +200,7 @@ async fn generate_proof(
     let proof = ethabi::encode(&[Token::Tuple(vec![
         Token::Bytes(block_proof),
         Token::FixedBytes(image_id),
-        Token::Bytes(result.receipt.journal),
+        Token::Bytes(result.receipt.journal.bytes),
     ])]);
 
     Ok(proof)

--- a/methods/guest/Cargo.lock
+++ b/methods/guest/Cargo.lock
@@ -1165,7 +1165,8 @@ dependencies = [
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
  "clap",
- "rust-eigenda-v2-common",
+ "ethabi",
+ "rust-eigenda-v2-common 0.1.3",
  "rust-kzg-bn254-primitives",
  "serde",
 ]
@@ -1761,7 +1762,7 @@ dependencies = [
  "risc0-steel",
  "risc0-zkvm",
  "risc0-zkvm-platform",
- "rust-eigenda-v2-common",
+ "rust-eigenda-v2-common 0.1.2",
  "rust-kzg-bn254-primitives",
  "rust-kzg-bn254-verifier",
  "tiny-keccak",
@@ -3184,6 +3185,26 @@ checksum = "48fd7bd8a6377e15ad9d42a8ec25371b94ddc67abe7c8b9127bec79bebaaae18"
 name = "rust-eigenda-v2-common"
 version = "0.1.2"
 source = "git+https://github.com/lambdaclass/eigenda-client-rs?branch=relocate_eigenda_cert_encoding#044b94bfaadf4a95a41ddc50378aab99f99851b5"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "ark-bn254",
+ "ark-ff 0.5.0",
+ "ark-poly",
+ "ark-serialize 0.5.0",
+ "bincode",
+ "ethabi",
+ "rust-kzg-bn254-primitives",
+ "serde",
+ "thiserror 1.0.69",
+ "tiny-keccak",
+]
+
+[[package]]
+name = "rust-eigenda-v2-common"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ed3a4520c365197ca700008f6566d03d50b098c009aaaa9677b90de9fc1700"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",

--- a/methods/guest/Cargo.lock
+++ b/methods/guest/Cargo.lock
@@ -1160,7 +1160,6 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
- "anyhow",
  "ark-bn254",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -132,11 +132,10 @@ fn main() {
 
     let mut proof_bytes = vec![];
     proof.g1.serialize_compressed(&mut proof_bytes).unwrap();
-    // Public outputs of the guest, eigenDAHash, commitment to the risc0 steel environment, blob info and proof, they are embedded on the risc0 proof
+    // Public outputs of the guest, eigenDAHash, commitment to the risc0 steel environment and proof, they are embedded on the risc0 proof
     let output = Output {
         hash: hash.to_vec(),
         env_commitment: env.commitment().abi_encode(),
-        inclusion_data: eigenda_cert.to_bytes().unwrap(),
         proof: proof_bytes,
     };
 

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -140,5 +140,5 @@ fn main() {
         proof: proof_bytes,
     };
 
-    env::commit(&output);
+    env::commit_slice(output.abi_encode());
 }

--- a/methods/guest/src/main.rs
+++ b/methods/guest/src/main.rs
@@ -140,5 +140,5 @@ fn main() {
         proof: proof_bytes,
     };
 
-    env::commit_slice(output.abi_encode());
+    env::commit_slice(&output.abi_encode());
 }


### PR DESCRIPTION
The guest now returns the full abi encoded journal instead of the hash.